### PR TITLE
Fix typo in git config --global

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ git config user.email "Example@example.com"
 🎯️ Git Config For Any Directory For User
 
 ```zsh
-git config --globle user.name YourName
+git config --global user.name YourName
 ```
 ```zsh
-git config --globle user.email "Example@example.com"
+git config --global user.email "Example@example.com"
 ```
 
 ### ⚠️ Note:


### PR DESCRIPTION
The command should be `git config --global`, not `git config --globle`